### PR TITLE
fix: ensure mysql8 compatibility

### DIFF
--- a/tutor/templates/hooks/mysql/init
+++ b/tutor/templates/hooks/mysql/init
@@ -15,5 +15,6 @@ done
 echo "MySQL is up and running"
 
 # edx-platform database
-mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'CREATE DATABASE IF NOT EXISTS {{ OPENEDX_MYSQL_DATABASE }};'
-mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'GRANT ALL ON {{ OPENEDX_MYSQL_DATABASE }}.* TO "{{ OPENEDX_MYSQL_USERNAME }}"@"%" IDENTIFIED BY "{{ OPENEDX_MYSQL_PASSWORD }}";'
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE DATABASE IF NOT EXISTS {{ OPENEDX_MYSQL_DATABASE }};"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{OPENEDX_MYSQL_USERNAME}}' IDENTIFIED BY '{{ OPENEDX_MYSQL_PASSWORD }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT ALL ON '{{ OPENEDX_MYSQL_DATABASE }}.*' TO '{{ OPENEDX_MYSQL_USERNAME }}'@'%';"


### PR DESCRIPTION
## Description

MySQL 8 drop the support for creating users by executing `GRANT ALL`. This commit splits the user creation and permission granting, therefore the newer MySQL versions are supported too.

MySQL 8 is supported by edx-platform: https://github.com/openedx/configuration/blob/1cdb0347c5e25dd88c4a64634ea931dc46d4f3cd/playbooks/roles/mysql/tasks/mysql.yml#L93-L98