### PR TITLE
fix: add --lazy-apps to uwsgi

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -265,6 +265,7 @@ CMD uwsgi \
     --thunder-lock \
     --single-interpreter \
     --enable-threads \
+    --lazy-apps \
     --processes=${UWSGI_WORKERS:-2} \
     --buffer-size=8192 \
     --wsgi-file $SERVICE_VARIANT/wsgi.py


### PR DESCRIPTION
Adds --lazy-apps to uwsgi to prevent `pymongo.errors.ServerSelectionTimeoutError` in case of a MongoDB failover.

```
PyMongo is not fork-safe. Care must be taken when using instances of MongoClient with fork(). Specifically, instances of MongoClient must not be copied from a parent process to a child process.
```
