### PR TITLE
fix: disable Redis' appendonly

### DIFF
--- a/tutor/templates/apps/redis/redis.conf
+++ b/tutor/templates/apps/redis/redis.conf
@@ -29,13 +29,13 @@ dbfilename dump.rdb
 rdb-del-sync-files no
 
 ############################## APPEND ONLY MODE ###############################
-
+# Disabled to prevent filling up the disk
 # http://redis.io/topics/persistence
-appendonly yes
-appendfilename "appendonly.aof"
-appendfsync everysec
-no-appendfsync-on-rewrite no
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
-aof-load-truncated yes
-aof-use-rdb-preamble yes
+# appendonly yes
+# appendfilename "appendonly.aof"
+# appendfsync everysec
+# no-appendfsync-on-rewrite no
+# auto-aof-rewrite-percentage 100
+# auto-aof-rewrite-min-size 64mb
+# aof-load-truncated yes
+# aof-use-rdb-preamble yes


### PR DESCRIPTION
## Description

This PR disables Redis' `appendonly` to prevent filling up disks.

## Supporting information

https://redis.io/docs/management/persistence/#append-only-file

## Testing instructions

1. Deploy a local cluster
2. Exec bash into the Redis container
3. Confirm no appendonly.aof file exists in /openedx/redis/data
4. Confirm `appendonly yes` is commented out in /openedx/redis/config/redis.conf

## Deadline

ASAP